### PR TITLE
Nuxt3 で SVG を利用する（Vite）

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,62 @@
+<script setup>
+import ExampleSvg from '~/assets/images/example1.svg'
+
+// const exampleSvgRequired = require('~/assets/images/example1.svg')
+const imageName = 'example1.svg'
+// const exampleSvgDynamicRequired = require(`~/assets/images/${imageName}`)
+</script>
+
 <template>
   <div>
-    <NuxtWelcome />
+    <h2>img 要素の src に文字列パスを指定したとき</h2>
+    <p>&lt;img src="~/assets/images/example1.svg" /&gt;</p>
+    <img width="200" src="~/assets/images/example1.svg" />
+
+    <h2>SVG ファイルを import したとき</h2>
+    <p>
+      import ExampleSvg from '~/assets/images/example1.svg'<br />
+      <br />
+      &lt;img :src="ExampleSvg" /&gt;
+    </p>
+    <img width="200" :src="ExampleSvg" />
+
+    <h2>SVG ファイルを require したとき（静的）</h2>
+    <p>
+      const exampleSvgRequired = require('~/assets/images/example1.svg')
+      <br />
+      &lt;img :src="exampleSvgRequired" /&gt;
+    </p>
+    <!-- <img width="200" :src="exampleSvgRequired" /> -->
+    <p>500 エラー</p>
+
+    <h2>SVG ファイルを require したとき（動的）</h2>
+    <p>
+      const imageName = 'example1.svg'<br />
+      const exampleSvgDynamicRequired = require(`~/assets/images/${imageName}`)<br />
+      <br />
+      &lt;img :src="exampleSvgDynamicRequired" /&gt;
+    </p>
+    <!-- <img width="200" :src="exampleSvgDynamicRequired" /> -->
+    <p>500 エラー</p>
+
+    <h2>CSS の background-image の url に文字列パスを指定したとき</h2>
+    <p>CSS）background-image: url("~/assets/images/example1.svg");</p>
+    <div class="background-image"></div>
+
+    <h2>style 属性で background-image の url を指定したとき</h2>
+    <p>
+      import ExampleSvg from '~/assets/images/example1.svg'<br />
+      <br />
+      &lt;div :style="`background-image: url(${ExampleSvg}});`"&gt;&lt;/div&gt;
+    </p>
+    <div :style="`width: 200px; height: 200px; background-image: url(${ExampleSvg});`"></div>
   </div>
 </template>
+
+<style scoped>
+.background-image {
+  width: 200px;
+  height: 200px;
+  background-image: url('~/assets/images/example1.svg');
+}
+</style>

--- a/app.vue
+++ b/app.vue
@@ -19,15 +19,6 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
     </p>
     <img width="200" :src="ExampleSvg" />
 
-    <h2>SVG ファイルを require したとき（静的）</h2>
-    <p>
-      const exampleSvgRequired = require('~/assets/images/example1.svg')
-      <br />
-      &lt;img :src="exampleSvgRequired" /&gt;
-    </p>
-    <!-- <img width="200" :src="exampleSvgRequired" /> -->
-    <p>500 エラー</p>
-
     <h2>動的パスの SVG</h2>
     <p>
       const imageName = 'example1'<br />

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <script setup>
-import ExampleSvg from '~/assets/images/example1.svg'
+import ExampleSvg from '~/assets/images/example1.svg?url'
 
 const imageName = 'example1'
 const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`)
@@ -8,12 +8,12 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`
 <template>
   <div>
     <h2>img 要素の src に文字列パスを指定したとき</h2>
-    <p>&lt;img src="~/assets/images/example1.svg" /&gt;</p>
-    <img width="200" src="~/assets/images/example1.svg" />
+    <p>&lt;img src="~/assets/images/example1.svg?url" /&gt;</p>
+    <img width="200" src="~/assets/images/example1.svg?url" />
 
     <h2>SVG ファイルを import したとき</h2>
     <p>
-      import ExampleSvg from '~/assets/images/example1.svg'<br />
+      import ExampleSvg from '~/assets/images/example1.svg?url'<br />
       <br />
       &lt;img :src="ExampleSvg" /&gt;
     </p>
@@ -36,7 +36,7 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`
 
     <h2>style 属性で background-image の url を指定したとき</h2>
     <p>
-      import ExampleSvg from '~/assets/images/example1.svg'<br />
+      import ExampleSvg from '~/assets/images/example1.svg?url'<br />
       <br />
       &lt;div :style="`background-image: url(${ExampleSvg}});`"&gt;&lt;/div&gt;
     </p>

--- a/app.vue
+++ b/app.vue
@@ -2,10 +2,7 @@
 import ExampleSvg from '~/assets/images/example1.svg'
 
 const imageName = 'example1'
-const dynamicPathSvg = new URL(
-  `./assets/images/${imageName}.svg`,
-  import.meta.url
-).href
+const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
 </script>
 
 <template>
@@ -34,13 +31,12 @@ const dynamicPathSvg = new URL(
     <h2>動的パスの SVG</h2>
     <p>
       const imageName = 'example1'<br />
-      const dynamicPathSvg = new URL(`./assets/images/${imageName}.svg`,
-      import.meta.url).href<br />
+      const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
       <br />
-      &lt;img :src="dynamicPathSvg" /&gt;
+      &lt;component :is="dynamicPathSvg" /&gt;
     </p>
-    <p>dynamicPathSvg: {{ dynamicPathSvg }}</p>
-    <img width="200" :src="dynamicPathSvg" />
+    <!-- <p>dynamicPathSvg: {{ dynamicPathSvg }}</p> -->
+    <component :is="dynamicPathSvg" />
 
     <h2>CSS の background-image の url に文字列パスを指定したとき</h2>
     <p>CSS）background-image: url("~/assets/images/example1.svg");</p>

--- a/app.vue
+++ b/app.vue
@@ -1,9 +1,11 @@
 <script setup>
 import ExampleSvg from '~/assets/images/example1.svg'
 
-// const exampleSvgRequired = require('~/assets/images/example1.svg')
-const imageName = 'example1.svg'
-// const exampleSvgDynamicRequired = require(`~/assets/images/${imageName}`)
+const imageName = 'example1'
+const dynamicPathSvg = new URL(
+  `./assets/images/${imageName}.svg`,
+  import.meta.url
+).href
 </script>
 
 <template>
@@ -29,15 +31,16 @@ const imageName = 'example1.svg'
     <!-- <img width="200" :src="exampleSvgRequired" /> -->
     <p>500 エラー</p>
 
-    <h2>SVG ファイルを require したとき（動的）</h2>
+    <h2>動的パスの SVG</h2>
     <p>
-      const imageName = 'example1.svg'<br />
-      const exampleSvgDynamicRequired = require(`~/assets/images/${imageName}`)<br />
+      const imageName = 'example1'<br />
+      const dynamicPathSvg = new URL(`./assets/images/${imageName}.svg`,
+      import.meta.url).href<br />
       <br />
-      &lt;img :src="exampleSvgDynamicRequired" /&gt;
+      &lt;img :src="dynamicPathSvg" /&gt;
     </p>
-    <!-- <img width="200" :src="exampleSvgDynamicRequired" /> -->
-    <p>500 エラー</p>
+    <p>dynamicPathSvg: {{ dynamicPathSvg }}</p>
+    <img width="200" :src="dynamicPathSvg" />
 
     <h2>CSS の background-image の url に文字列パスを指定したとき</h2>
     <p>CSS）background-image: url("~/assets/images/example1.svg");</p>
@@ -49,7 +52,9 @@ const imageName = 'example1.svg'
       <br />
       &lt;div :style="`background-image: url(${ExampleSvg}});`"&gt;&lt;/div&gt;
     </p>
-    <div :style="`width: 200px; height: 200px; background-image: url(${ExampleSvg});`"></div>
+    <div
+      :style="`width: 200px; height: 200px; background-image: url(${ExampleSvg});`"
+    ></div>
   </div>
 </template>
 

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <script setup>
-import ExampleSvg from '~/assets/images/example1.svg?url'
+import ExampleSvg from '~/assets/images/example1.svg'
 
 const imageName = 'example1'
 const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`)
@@ -8,12 +8,12 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`
 <template>
   <div>
     <h2>img 要素の src に文字列パスを指定したとき</h2>
-    <p>&lt;img src="~/assets/images/example1.svg?url" /&gt;</p>
-    <img width="200" src="~/assets/images/example1.svg?url" />
+    <p>&lt;img src="~/assets/images/example1.svg" /&gt;</p>
+    <img width="200" src="~/assets/images/example1.svg" />
 
     <h2>SVG ファイルを import したとき</h2>
     <p>
-      import ExampleSvg from '~/assets/images/example1.svg?url'<br />
+      import ExampleSvg from '~/assets/images/example1.svg'<br />
       <br />
       &lt;img :src="ExampleSvg" /&gt;
     </p>
@@ -36,7 +36,7 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`
 
     <h2>style 属性で background-image の url を指定したとき</h2>
     <p>
-      import ExampleSvg from '~/assets/images/example1.svg?url'<br />
+      import ExampleSvg from '~/assets/images/example1.svg'<br />
       <br />
       &lt;div :style="`background-image: url(${ExampleSvg}});`"&gt;&lt;/div&gt;
     </p>

--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,8 @@
 <script setup>
 import ExampleSvg from '~/assets/images/example1.svg'
 
-const imageName = 'example1.svg'
-const dynamicPathSvg = await import(`./assets/images/${imageName}?component`)
+const imageName = 'example1'
+const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`)
 </script>
 
 <template>
@@ -22,7 +22,7 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}?component`)
     <h2>動的パスの SVG</h2>
     <p>
       const imageName = 'example1.svg'<br />
-      const dynamicPathSvg = await import(`./assets/images/${imageName}?component`)<br />
+      const dynamicPathSvg = await import(`./assets/images/${imageName}.svg?component`)<br />
       <br />
       &lt;component :is="dynamicPathSvg" /&gt;
     </p>

--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,8 @@
 <script setup>
 import ExampleSvg from '~/assets/images/example1.svg'
 
-const imageName = 'example1'
-const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
+const imageName = 'example1.svg'
+const dynamicPathSvg = await import(`./assets/images/${imageName}?component`)
 </script>
 
 <template>
@@ -21,13 +21,14 @@ const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
 
     <h2>動的パスの SVG</h2>
     <p>
-      const imageName = 'example1'<br />
-      const dynamicPathSvg = await import(`./assets/images/${imageName}.svg`)
+      const imageName = 'example1.svg'<br />
+      const dynamicPathSvg = await import(`./assets/images/${imageName}?component`)<br />
       <br />
       &lt;component :is="dynamicPathSvg" /&gt;
     </p>
-    <!-- <p>dynamicPathSvg: {{ dynamicPathSvg }}</p> -->
-    <component :is="dynamicPathSvg" />
+    <div style="width: 200px;">
+      <component :is="dynamicPathSvg" />
+    </div>
 
     <h2>CSS の background-image の url に文字列パスを指定したとき</h2>
     <p>CSS）background-image: url("~/assets/images/example1.svg");</p>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import svgLoader from 'vite-svg-loader'
+
 export default defineNuxtConfig({
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  // @ts-ignore TS2345: Argument of type '{ devtools: { enabled: boolean; }; vite: { plugins: Plugin_2[]; }; }' is not assignable to parameter of type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.   Object literal may only specify known properties, and 'vite' does not exist in type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.
+  vite: {
+    plugins: [svgLoader()],
+  },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,6 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   // @ts-ignore TS2345: Argument of type '{ devtools: { enabled: boolean; }; vite: { plugins: Plugin_2[]; }; }' is not assignable to parameter of type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.   Object literal may only specify known properties, and 'vite' does not exist in type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.
   vite: {
-    plugins: [svgLoader({ defaultImport: 'url' })],
+    plugins: [svgLoader()],
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,6 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   // @ts-ignore TS2345: Argument of type '{ devtools: { enabled: boolean; }; vite: { plugins: Plugin_2[]; }; }' is not assignable to parameter of type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.   Object literal may only specify known properties, and 'vite' does not exist in type 'InputConfig<NuxtConfig, ConfigLayerMeta>'.
   vite: {
-    plugins: [svgLoader()],
+    plugins: [svgLoader({ defaultImport: 'url' })],
   },
 })

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@nuxt/devtools": "latest",
     "@types/node": "^18",
-    "nuxt": "^3.5.2"
+    "nuxt": "^3.5.2",
+    "prettier": "^2.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@nuxt/devtools": "latest",
     "@types/node": "^18",
     "nuxt": "^3.5.2",
-    "prettier": "^2.8.8"
+    "prettier": "^2.8.8",
+    "vite-svg-loader": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,7 +1100,7 @@
     "@vue/compiler-core" "3.3.4"
     "@vue/shared" "3.3.4"
 
-"@vue/compiler-sfc@3.3.4", "@vue/compiler-sfc@^3.3.4":
+"@vue/compiler-sfc@3.3.4", "@vue/compiler-sfc@^3.2.20", "@vue/compiler-sfc@^3.3.4":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz#b19d942c71938893535b46226d602720593001df"
   integrity sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==
@@ -5616,6 +5616,14 @@ vite-plugin-vue-inspector@^3.4.2:
     kolorist "^1.7.0"
     magic-string "^0.30.0"
     shell-quote "^1.8.0"
+
+vite-svg-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vite-svg-loader/-/vite-svg-loader-4.0.0.tgz#1cec4337dba3c23ab13bcabb111896e251b047ac"
+  integrity sha512-0MMf1yzzSYlV4MGePsLVAOqXsbF5IVxbn4EEzqRnWxTQl8BJg/cfwIzfQNmNQxZp5XXwd4kyRKF1LytuHZTnqA==
+  dependencies:
+    "@vue/compiler-sfc" "^3.2.20"
+    svgo "^3.0.2"
 
 "vite@^3.0.0 || ^4.0.0", vite@~4.3.9:
   version "4.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,6 +4562,11 @@ postcss@^8.1.10, postcss@^8.4.23, postcss@^8.4.24:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 pretty-bytes@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-6.1.0.tgz#1d1cc9aae1939012c74180b679da6684616bf804"
@@ -5777,6 +5782,7 @@ wide-align@^1.1.2, wide-align@^1.1.5:
     string-width "^1.0.2 || 2 || 3 || 4"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- [x] img 要素の src に文字列パスを指定したとき

```
<img src="~/assets/images/example1.svg" />
```

- [x] SVG ファイルを import したとき

```
import ExampleSvg from '~/assets/images/example1.svg'

<img :src="ExampleSvg" />
```

- [ ] SVG ファイルを require したとき（静的）

```
const exampleSvgRequired = require('~/assets/images/example1.svg')
<img :src="exampleSvgRequired" />
```

- [ ] SVG ファイルを require したとき（動的）

```
const imageName = 'example1.svg'
const exampleSvgDynamicRequired = require(`~/assets/images/${imageName}`)

<img :src="exampleSvgDynamicRequired" />
```

- [x] CSS の background-image の url に文字列パスを指定したとき

```css
background-image: url("~/assets/images/example1.svg");
```

- [x] style 属性で background-image の url を指定したとき

```
import ExampleSvg from '~/assets/images/example1.svg'

<div :style="`background-image: url(${ExampleSvg}});`"></div>
```

## Links

Samples Vector SVG Icon - SVG Repo
https://www.svgrepo.com/svg/4733/samples

SVG 画像の拝借元。

---

静的アセットの取り扱い | Vite
https://ja.vitejs.dev/guide/assets.html

---

Dynamic import
https://ja.vitejs.dev/guide/features.html#dynamic-import
